### PR TITLE
LINE トークン ・ OpenAI API キーをシークレットから取得する

### DIFF
--- a/aws_systems_manager.py
+++ b/aws_systems_manager.py
@@ -1,0 +1,22 @@
+import boto3
+from botocore.exceptions import ClientError
+
+# AWS region name
+AWS_REGION = "ap-northeast-1"
+
+
+def get_secret(secret_key):
+    try:
+        # Create a client for AWS Systems Manager
+        ssm = boto3.client('ssm', region_name=AWS_REGION)
+
+        # Get the secret from AWS SSM
+        response = ssm.get_parameter(
+            Name=secret_key,
+            WithDecryption=True
+        )
+
+        # Return the value of the secret
+        return response['Parameter']['Value']
+    except ClientError as e:
+        raise e


### PR DESCRIPTION
LINE のチャネルトークンやシークレットトークン、OpenAI の API キーなど秘匿情報は AWS Systems Manager Parameter Store に登録して隠蔽します。

AWS Systems Manager のシークレットの登録方法は後述しますので、シークレットの値を取得するコードを先に出します。

boto3 で簡単に AWS System Manager から値を取得することが可能です。